### PR TITLE
Fix Typo and missing info

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Clone GrblServer on Raspberry Pi:
 	git clone https://github.com/cho45/GrblServer.git
 	cd GrblServer
 	npm install
+
+Create config/local.json. You must edit "serialPort" path.
+
+	cp config/default.json config/local.json
 	vi config/local.json
 
 Edit /etc/inittab to auto login by user pi:

--- a/browser/src/app.html
+++ b/browser/src/app.html
@@ -518,7 +518,7 @@
 						<paper-menu class="menu-content" selected="{{selectedSubMenu}}">
 							<paper-item>Dashboard</paper-item>
 							<paper-item>Jogging</paper-item>
-							<paper-item>Commnad</paper-item>
+							<paper-item>Command</paper-item>
 							<paper-item>Preview</paper-item>
 						</paper-menu>
 					</paper-submenu>


### PR DESCRIPTION
Fixed a typo in the menu
Updated Readme to include missed command that might be confusing for some.
